### PR TITLE
Fix exception types on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ $ python tests/__init__.py
 >>> zipcodes.matching('0646a')
 Traceback (most recent call last):
   ...
-TypeError: Invalid characters, zipcode may only contain digits and "-".
+ValueError: Invalid characters, zipcode may only contain digits and "-".
 
 >>> zipcodes.matching('064690')
 Traceback (most recent call last):
   ...
-TypeError: Invalid format, zipcode must be of the format: "#####" or "#####-####"
+ValueError: Invalid format, zipcode must be of the format: "#####" or "#####-####"
 
 >>> zipcodes.matching(None)
 Traceback (most recent call last):


### PR DESCRIPTION
Both examples `zipcodes.matching('0646a')` and `zipcodes.matching('064690')` raise a `ValueError`--instead of the documented `TypeError`--as they are strings and only fail on the [`_clean_zipcode`](https://github.com/rafascar/Zipcodes/blob/master/zipcodes/__init__.py#L49) step.

Reproducible on `zipcodes==1.2.0`
```
>>> zipcodes.matching('0646a')
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/zipcodes/__init__.py", line 55, in decorator
    _clean(zipcode, min(len(zipcode), _valid_zipcode_length)), *args, **kwargs
  File "/usr/local/lib/python3.9/site-packages/zipcodes/__init__.py", line 122, in _clean
    raise ValueError('Invalid characters, zipcode may only contain digits and "-".')
ValueError: Invalid characters, zipcode may only contain digits and "-".

>>> zipcodes.matching('064690')
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.9/site-packages/zipcodes/__init__.py", line 55, in decorator
    _clean(zipcode, min(len(zipcode), _valid_zipcode_length)), *args, **kwargs
  File "/usr/local/lib/python3.9/site-packages/zipcodes/__init__.py", line 117, in _clean
    raise ValueError(
ValueError: Invalid format, zipcode must be of the format: "#####" or "#####-####"
```